### PR TITLE
fix

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -53,3 +53,5 @@ CREATE TABLE some_table
     string_list VARCHAR(500),
     PRIMARY KEY(id)
 );
+
+ALTER TABLE inquiry_tag ALTER COLUMN id RESTART WITH 8


### PR DESCRIPTION
> insert時にプライマリーキー違反ということでテストがパスしないという状況です。xmlのuseGeneratedKeysにはtrueを指定し> ているので、何故こうなってしまうのか分からない、といった状況です。
```
inquiry_tagに対し。
data.sqlで予めID指定で７までインサートするという前提であるならば
scheme.sqlでシーケンスを8から開始するように設定しておく

